### PR TITLE
Update setup.md

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,6 +1,6 @@
 # Getting started
 
-Baltica comprise of a collection of workflows and analysis scripts. Workflows are powered by [Snakemake](https://snakemake.readthedocs.io/en/stable/) [^1]. Analysis are done with the Rlang. Bellow we document how to obtain install the methods on which Baltica depends.    
+Baltica is comprised of a collection of workflows and analysis scripts. Workflows are powered by [Snakemake](https://snakemake.readthedocs.io/en/stable/) [^1]. Analysis are done with the Rlang. Below we document how to obtain and install the methods on which Baltica depends.    
 
 ## Install miniconda
 
@@ -66,7 +66,7 @@ conda create --name leafcutter python=2.7 --yes
 conda activate leafcutter
 conda install -c bioconda samtools r-base=3.6 --yes
 
-Rscript -e "install.packages('devtools', repos='http://cran.us.r-project.org', dependencies=TRUE)"
+Rscript -e "install.packages('devtools', repos='http://cran.us.r-project.org',warning dependencies=TRUE)"
 Rscript -e "Sys.setenv(TAR = '/bin/tar'); devtools::install_github('stan-dev/rstantools')"
 Rscript -e "Sys.setenv(TAR = '/bin/tar'); devtools::install_github('davidaknowles/leafcutter/leafcutter')"
 ```


### PR DESCRIPTION

- Maybe first a stupid question: but do you need to state that for the analysis a UNIX operating system is necessary? I know that this is probably obvious, just wanted to make sure.

- Then I again made some minor text changes (please revise them and revert if you feel they made things worse).

- Specific issues:
   
- Line 28-40: I could not install snakemake with the command you provided, probably because my python was too new? I got the following error:

`UnsatisfiableError: The following specifications were found to be incompatible with the existing python installation in your environment:`

`Specifications:`

`  - snakemake==5.2 -> python[version='>=3.5,<3.6.0a0|>=3.6,<3.7.0a0']`

`Your python: python=3.7`

- Line 57: I followed the other commands to install majiq, but installation of the last command failed for me. I will try to attach a log file, which might help you (and me) to understand why... at first glance it seems to have a problem with gcc, i.e. with my C compiler and C++ compiler. 
[majiq_install_error.txt](https://github.com/dieterich-lab/Baltica/files/5001566/majiq_install_error.txt)


- Line 69: I could not install devtools with the given command. several packages were not available:
` ERROR: dependencies ‘usethis’, ‘covr’, ‘httr’, ‘rversions’ are not available for package ‘devtools’ *removing ‘/home/volker/miniconda3/envs/leafcutter/lib/R/library/devtools’ `

- Line 87: first of all, you probably need to tell people where to find the "junctionseq.yml" (btw, there is no "junctionseq-env" anywere?), although you point this out at the top, I would probably re-iterate here to make sure people understand. Then, I simply could not run the command:

`(base) volker@gehring-workstation1:~/Tools/baltica/envs$ conda env create -f junctionseq-env.yml --yes usage: conda-env [-h] {create,export,list,remove,update,config} ... conda-env: error: unrecognized arguments: --yes `

Without the "--yes" command and changing to junctionseq.yml, it seems to work. The next command should also be "conda activate junctionseq" and not "leafcutter".

- Line 89: Again, this command does not complete installation:

ERROR: lazy loading failed for package ‘Hmisc’
* removing ‘/home/volker/miniconda3/envs/junctionseq/lib/R/library/Hmisc’
ERROR: dependencies ‘SummarizedExperiment’, ‘genefilter’, ‘geneplotter’, ‘Hmisc’ are not available for package ‘DESeq2’
* removing ‘/home/volker/miniconda3/envs/junctionseq/lib/R/library/DESeq2’
ERROR: dependencies ‘SummarizedExperiment’, ‘DESeq2’, ‘Hmisc’, ‘genefilter’, ‘geneplotter’ are not available for package ‘JunctionSeq’
* removing ‘/home/volker/miniconda3/envs/junctionseq/lib/R/library/JunctionSeq’


- Line 93: with installed Baltica you mean the commands listed in "README.md"?

BTW, I installed snakemake via (https://snakemake.readthedocs.io/en/stable/getting_started/installation.html) and got the "python setup.py install" command to run properly. However, I could not test the next command "baltica majiq --configfile baltica/config.yml --use-envmodule", as the output was just: "baltica: error: unrecognized arguments: --configfile"

Hope those comments help in any way. I would be happy to try to fix those problems. Maybe they are mostly because of issues with my machine...